### PR TITLE
Dummy-Lernkategorien werden angezeigt

### DIFF
--- a/client/src/Dashboard/Dashboard.css
+++ b/client/src/Dashboard/Dashboard.css
@@ -4,6 +4,9 @@
     --sidebar-section-padding: .5rem;
 
     --main-padding: .5rem;
+    --main-gap: .5rem;
+
+    --learning-section-gap: 1rem;
 }
 
 .dashboard-container {
@@ -30,7 +33,21 @@
     }
 
     > main {
+        display: flex;
+        flex-direction: column;
+        gap: var(--main-gap);
         padding: var(--main-padding);
     }
 }
 
+div.learning-section-container {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--learning-section-gap);
+
+    > section {
+        padding: 4rem;
+        background-color: var(--primary-color);
+        color: var(--secondary-color);
+    }
+}

--- a/client/src/Dashboard/DashboardContent/DashboardContentLayout.tsx
+++ b/client/src/Dashboard/DashboardContent/DashboardContentLayout.tsx
@@ -1,6 +1,8 @@
 import { Navigate, useParams } from "react-router";
 
 import { dashboardSectionData } from "../../data/dashboard.data";
+import DashboardLernen from "./DashboardLernen";
+import { JSX } from "react";
 
 export default function DashboardContentLayout() {
   const { section } = useParams();
@@ -10,10 +12,20 @@ export default function DashboardContentLayout() {
 
   if (!currentSection) return <Navigate to="/dashboard" />;
 
+  let content: JSX.Element | null
+
+  switch(currentSection.section) {
+    case 'Lernen': 
+      content = <DashboardLernen />
+      break;
+    default: content = null
+  }
+
   return (
     <>
       <h1>{currentSection.section}</h1>
       <p>{currentSection.description}</p>
+      {content}
     </>
   );
 }

--- a/client/src/Dashboard/DashboardContent/DashboardLernen.tsx
+++ b/client/src/Dashboard/DashboardContent/DashboardLernen.tsx
@@ -1,0 +1,13 @@
+import { dashboardLernenSections } from "../../data/dashboard.data";
+
+export default function DashboardLernen() {
+  return (
+    <div className="learning-section-container">
+      {dashboardLernenSections.map((section) => (
+        <section>
+            <h3>{section}</h3>
+        </section>
+      ))}
+    </div>
+  );
+}

--- a/client/src/data/dashboard.data.ts
+++ b/client/src/data/dashboard.data.ts
@@ -26,3 +26,10 @@ export const dashboardSectionData: DashboardContent[] = [
         urlPath: "einstellungen"
     }
 ]
+
+export const dashboardLernenSections: string[] = [
+    "Addition",
+    "Subtraktion",
+    "Multiplikation",
+    "Division"
+]


### PR DESCRIPTION
- DashboardContentLayout fügt den Inhalt vom "Lernen" Bereich hinzu
- Kategorien werden von `dashboard.data.ts` ausgelesen